### PR TITLE
Fix headers

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -59,6 +59,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->arrayNode('default_headers')
                                 ->useAttributeAsKey('name')
+                                ->normalizeKeys(false)
                                 ->prototype('scalar')->end()
                             ->end()
                             ->scalarNode('proxy')


### PR DESCRIPTION
Symfony for array configuration node always converts keys unless explicitly disabled.

In this case we found out that sending a header with a dash like `Webhook-Signature` becomes `Webhook_signature` so n8n authorization fails when you expect to receive the header with a dash.