### PR TITLE
Feature/symfony 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
-          tools: php-cs-fixer:3.64
+          php-version: '8.4'
+          tools: php-cs-fixer:3.91
 
       - name: Check code style
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: 1
         run: php-cs-fixer fix --dry-run --diff
 
   phpstan:
@@ -31,7 +29,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
 
       - name: Get composer cache directory
@@ -70,7 +68,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: pcov
           extensions: json, mbstring
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  COMPOSER_NO_AUDIT: 1
+
 jobs:
   php-cs-fixer:
     name: PHP-CS-Fixer
@@ -175,7 +178,7 @@ jobs:
           mkdir -p var/cache var/log
 
       - name: Run tests with coverage
-        run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
+        run: vendor/bin/phpunit --testsuite=Unit --coverage-text --coverage-clover=coverage.xml --do-not-fail-on-warning
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  COMPOSER_NO_AUDIT: 1
-
 jobs:
   php-cs-fixer:
     name: PHP-CS-Fixer
@@ -19,26 +16,22 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.2'
           tools: php-cs-fixer:3.91
 
       - name: Check code style
         run: php-cs-fixer fix --dry-run --diff
 
   phpstan:
-    name: PHPStan (PHP ${{ matrix.php }})
+    name: PHPStan
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.2'
           coverage: none
 
       - name: Get composer cache directory
@@ -49,13 +42,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-php${{ matrix.php }}-
+          key: ${{ runner.os }}-composer-phpstan-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-phpstan-
 
       - name: Install composer dependencies
         run: |
           composer config --no-plugins allow-plugins.php-http/discovery true
-          composer install --no-interaction --no-progress
+          composer install --no-interaction --no-progress --no-audit
 
       - name: Verify phpstan.neon exists
         run: |
@@ -131,7 +124,7 @@ jobs:
       - name: Install composer dependencies
         run: |
           composer config --no-plugins allow-plugins.php-http/discovery true
-          composer update --no-interaction --no-progress --prefer-dist
+          composer update --no-interaction --no-progress --prefer-dist --no-audit
 
       - name: Create test directories
         run: |
@@ -170,7 +163,7 @@ jobs:
       - name: Install composer dependencies
         run: |
           composer config --no-plugins allow-plugins.php-http/discovery true
-          composer install --no-interaction --no-progress
+          composer install --no-interaction --no-progress --no-audit
 
       - name: Create test directories
         run: |
@@ -178,7 +171,7 @@ jobs:
           mkdir -p var/cache var/log
 
       - name: Run tests with coverage
-        run: vendor/bin/phpunit --testsuite=Unit --coverage-text --coverage-clover=coverage.xml --do-not-fail-on-warning
+        run: vendor/bin/phpunit --testsuite=Unit --coverage-text --coverage-clover=coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -187,30 +180,20 @@ jobs:
           fail_ci_if_error: false
 
   deprecation-check:
-    name: Deprecation Check (PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }})
+    name: Deprecation Check
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - php: '8.3'
-            symfony: '6.4.*'
-          - php: '8.3'
-            symfony: '7.1.*'
-          - php: '8.4'
-            symfony: '8.0.*'
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.4'
           coverage: none
 
       - name: Configure Symfony version
         run: |
-          composer config extra.symfony.require "${{ matrix.symfony }}"
+          composer config extra.symfony.require "8.0.*"
 
       - name: Install Symfony Flex
         run: |
@@ -220,7 +203,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer config --no-plugins allow-plugins.php-http/discovery true
-          composer update --no-interaction --no-progress
+          composer update --no-interaction --no-progress --no-audit
 
       - name: Create test directories
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   php-cs-fixer:
@@ -23,15 +25,19 @@ jobs:
         run: php-cs-fixer fix --dry-run --diff
 
   phpstan:
-    name: PHPStan
+    name: PHPStan (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Get composer cache directory
@@ -42,8 +48,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-php${{ matrix.php }}-
 
       - name: Install composer dependencies
         run: |
@@ -56,21 +62,52 @@ jobs:
             echo "phpstan.neon does not exist!"
             exit 1
           fi
-          cat phpstan.neon
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse
 
   tests:
-    name: Tests
+    name: Tests (PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PHP 8.2 combinations
+          - php: '8.2'
+            symfony: '6.4.*'
+          - php: '8.2'
+            symfony: '7.0.*'
+          - php: '8.2'
+            symfony: '7.1.*'
+          - php: '8.2'
+            symfony: '8.0.*'
+          # PHP 8.3 combinations
+          - php: '8.3'
+            symfony: '6.4.*'
+          - php: '8.3'
+            symfony: '7.0.*'
+          - php: '8.3'
+            symfony: '7.1.*'
+          - php: '8.3'
+            symfony: '8.0.*'
+          # PHP 8.4 combinations
+          - php: '8.4'
+            symfony: '6.4.*'
+          - php: '8.4'
+            symfony: '7.0.*'
+          - php: '8.4'
+            symfony: '7.1.*'
+          - php: '8.4'
+            symfony: '8.0.*'
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php }}
           coverage: pcov
           extensions: json, mbstring
 
@@ -82,8 +119,56 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-php${{ matrix.php }}-sf${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-php${{ matrix.php }}-
+
+      - name: Configure Symfony version
+        run: |
+          composer config extra.symfony.require "${{ matrix.symfony }}"
+
+      - name: Install Symfony Flex
+        run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex
+
+      - name: Install composer dependencies
+        run: |
+          composer config --no-plugins allow-plugins.php-http/discovery true
+          composer update --no-interaction --no-progress --prefer-dist
+
+      - name: Create test directories
+        run: |
+          mkdir -p tests/Unit tests/Functional
+          mkdir -p var/cache var/log
+
+      - name: Run tests
+        env:
+          SYMFONY_DEPRECATIONS_HELPER: max[direct]=0
+        run: vendor/bin/phpunit --testsuite=Unit
+
+  tests-coverage:
+    name: Tests with Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: pcov
+          extensions: json, mbstring
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-coverage-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-coverage-
 
       - name: Install composer dependencies
         run: |
@@ -95,17 +180,51 @@ jobs:
           mkdir -p tests/Unit tests/Functional
           mkdir -p var/cache var/log
 
-      - name: Run unit tests
-        run: vendor/bin/phpunit --testsuite=Unit
-
-      - name: Run functional tests
-        run: vendor/bin/phpunit --testsuite=Functional
-
-      - name: Run all tests with coverage
+      - name: Run tests with coverage
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
+
+  deprecation-check:
+    name: Deprecation Check (Symfony ${{ matrix.symfony }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        symfony: ['6.4.*', '7.1.*', '8.0.*']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Configure Symfony version
+        run: |
+          composer config extra.symfony.require "${{ matrix.symfony }}"
+
+      - name: Install Symfony Flex
+        run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex
+
+      - name: Install dependencies
+        run: |
+          composer config --no-plugins allow-plugins.php-http/discovery true
+          composer update --no-interaction --no-progress
+
+      - name: Create test directories
+        run: |
+          mkdir -p tests/Unit tests/Functional
+          mkdir -p var/cache var/log
+
+      - name: Run deprecation check
+        env:
+          SYMFONY_DEPRECATIONS_HELPER: max[self]=0&max[direct]=0
+        run: vendor/bin/phpunit --testsuite=Unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,25 +71,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # PHP 8.2 combinations
+          # PHP 8.2 combinations (Symfony 6.4 and 7.x only)
           - php: '8.2'
             symfony: '6.4.*'
           - php: '8.2'
             symfony: '7.0.*'
           - php: '8.2'
             symfony: '7.1.*'
-          - php: '8.2'
-            symfony: '8.0.*'
-          # PHP 8.3 combinations
+          # PHP 8.3 combinations (Symfony 6.4 and 7.x only)
           - php: '8.3'
             symfony: '6.4.*'
           - php: '8.3'
             symfony: '7.0.*'
           - php: '8.3'
             symfony: '7.1.*'
-          - php: '8.3'
-            symfony: '8.0.*'
-          # PHP 8.4 combinations
+          # PHP 8.4 combinations (all Symfony versions including 8.0)
           - php: '8.4'
             symfony: '6.4.*'
           - php: '8.4'
@@ -188,19 +184,25 @@ jobs:
           fail_ci_if_error: false
 
   deprecation-check:
-    name: Deprecation Check (Symfony ${{ matrix.symfony }})
+    name: Deprecation Check (PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        symfony: ['6.4.*', '7.1.*', '8.0.*']
+        include:
+          - php: '8.3'
+            symfony: '6.4.*'
+          - php: '8.3'
+            symfony: '7.1.*'
+          - php: '8.4'
+            symfony: '8.0.*'
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Configure Symfony version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install composer dependencies
         run: |
           composer config --no-plugins allow-plugins.php-http/discovery true
-          composer install --no-interaction --no-progress --no-audit
+          composer install --no-interaction --no-progress
 
       - name: Verify phpstan.neon exists
         run: |
@@ -163,7 +163,7 @@ jobs:
       - name: Install composer dependencies
         run: |
           composer config --no-plugins allow-plugins.php-http/discovery true
-          composer install --no-interaction --no-progress --no-audit
+          composer install --no-interaction --no-progress
 
       - name: Create test directories
         run: |

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -11,6 +11,7 @@ $finder = (new PhpCsFixer\Finder())
 ;
 
 return (new PhpCsFixer\Config())
+    ->setUnsupportedPhpVersionAllowed(true)
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Elegant integration between Symfony applications and n8n workflow automation pla
 - **Multi-instance support** for different environments
 - **Dry run mode** for testing without actual sending
 
+## Requirements
+
+| Version | PHP | Symfony |
+|---------|-----|---------|
+| 1.2+    | ^8.2 | 6.4, 7.x, 8.0 |
+| 1.0-1.1 | ^8.1 | 6.4, 7.0 |
+
 ## Quick Start
 
 ### 1. Installation

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Elegant integration between Symfony applications and n8n workflow automation pla
 
 | Version | PHP | Symfony |
 |---------|-----|---------|
-| 1.2+    | ^8.2 | 6.4, 7.x, 8.0 |
-| 1.0-1.1 | ^8.1 | 6.4, 7.0 |
+| 1.3+    | ^8.2 | 6.4, 7.x |
+| 1.3+    | ^8.4 | 8.0 |
+| 1.0-1.2 | ^8.1 | 6.4, 7.0 |
+
+> **Note:** Symfony 8.0 requires PHP 8.4+
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -259,11 +259,11 @@ class N8nMonitoringListener implements EventSubscriberInterface
 
 ## Test Application
 
-The `dev/` directory contains a test application with Docker support:
+The `dev/` directory contains a test application with Docker support (PHP 8.2 + PHP 8.4).
 
 ### Setup
 
-1. Start Docker container:
+1. Start Docker containers:
 ```bash
 task up
 ```
@@ -296,21 +296,30 @@ Application will be available at http://localhost:8080
 ```bash
 # Environment management
 task init          # Initialize development environment
-task up            # Start Docker containers
+task up            # Start Docker containers (PHP 8.2 + 8.4)
 task down          # Stop Docker containers
 task restart       # Restart environment
 task logs          # Show logs
 
 # Development
 task serve         # Start dev server
-task shell         # Shell into dev container
-
-# N8n testing
-task test:health   # Health check
+task shell         # Shell into PHP 8.2 container
+task shell84       # Shell into PHP 8.4 container
 
 # Testing
-task test          # Run PHPUnit tests
+task test          # Run PHPUnit tests (PHP 8.2)
+task test:84       # Run PHPUnit tests (PHP 8.4)
+task test:coverage # Run tests with coverage report
+
+# Symfony Version Matrix
+task test:sf64     # Test with Symfony 6.4 (PHP 8.2)
+task test:sf71     # Test with Symfony 7.1 (PHP 8.2)
+task test:sf80     # Test with Symfony 8.0 (PHP 8.4)
+task test:matrix   # Run full test matrix
+
+# Code Quality
 task stan          # PHPStan analysis
+task cs            # Check code style
 task cs:fix        # Fix code style
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,7 +2,8 @@ version: '3'
 
 vars:
   COMPOSE: docker compose
-  CONTAINER_NAME: n8n-bundle-php
+  PHP82: n8n-bundle-php
+  PHP84: n8n-bundle-php84
 
 tasks:
   # Setup Development Environment
@@ -16,7 +17,7 @@ tasks:
   composer:install:
     desc: 'Install composer dependencies'
     cmd: |
-      docker exec {{ .CONTAINER_NAME }} sh -c "
+      docker exec {{ .PHP82 }} sh -c "
         if ! command -v composer > /dev/null 2>&1; then
           echo 'Installing Composer...'
           curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
@@ -27,9 +28,8 @@ tasks:
 
   # Docker Management
   up:
-    desc: 'Start development environment'
-    cmd: |
-      {{ .COMPOSE }} up -d
+    desc: 'Start development environment (PHP 8.2 + 8.4)'
+    cmd: '{{ .COMPOSE }} up -d'
     aliases: ['u']
 
   down:
@@ -51,52 +51,87 @@ tasks:
 
   # Development Tasks
   shell:
-    desc: 'Open shell in PHP container'
-    cmd: 'docker exec -it {{ .CONTAINER_NAME }} sh'
-    aliases:
-      - sh
+    desc: 'Open shell in PHP 8.2 container'
+    cmd: 'docker exec -it {{ .PHP82 }} sh'
+    aliases: ['sh']
+
+  shell84:
+    desc: 'Open shell in PHP 8.4 container'
+    cmd: 'docker exec -it {{ .PHP84 }} sh'
 
   serve:
     desc: 'Start development server'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} php -S 0.0.0.0:8080 -t dev/'
-    aliases:
-      - dev
+    cmd: 'docker exec {{ .PHP82 }} php -S 0.0.0.0:8080 -t dev/'
+    aliases: ['dev']
 
   # Testing
+  test:
+    desc: 'Run PHPUnit tests (PHP 8.2)'
+    cmd: 'docker exec {{ .PHP82 }} vendor/bin/phpunit --testsuite=Unit'
+
+  test:84:
+    desc: 'Run PHPUnit tests (PHP 8.4)'
+    cmd: 'docker exec {{ .PHP84 }} vendor/bin/phpunit --testsuite=Unit'
+
+  test:coverage:
+    desc: 'Run tests with coverage report'
+    cmd: 'docker exec {{ .PHP82 }} vendor/bin/phpunit --testsuite=Unit --coverage-html=var/coverage'
+
   test:health:
     desc: 'Check application health'
     cmd: 'curl -X GET http://localhost:8080/demo/health'
 
-  test:
-    desc: 'Run all PHPUnit tests'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} vendor/bin/phpunit'
+  # Symfony Version Matrix Testing
+  test:sf64:
+    desc: 'Test with Symfony 6.4 (PHP 8.2)'
+    cmd: |
+      docker exec {{ .PHP82 }} sh -c "
+        composer config extra.symfony.require '6.4.*' &&
+        composer update --no-interaction --no-progress &&
+        vendor/bin/phpunit --testsuite=Unit
+      "
 
-  test:unit:
-    desc: 'Run unit tests only'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} vendor/bin/phpunit --testsuite=Unit'
+  test:sf71:
+    desc: 'Test with Symfony 7.1 (PHP 8.2)'
+    cmd: |
+      docker exec {{ .PHP82 }} sh -c "
+        composer config extra.symfony.require '7.1.*' &&
+        composer update --no-interaction --no-progress &&
+        vendor/bin/phpunit --testsuite=Unit
+      "
 
-  test:coverage:
-    desc: 'Run tests with coverage report'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} vendor/bin/phpunit --coverage-html=var/coverage'
+  test:sf80:
+    desc: 'Test with Symfony 8.0 (PHP 8.4)'
+    cmd: |
+      docker exec {{ .PHP84 }} sh -c "
+        composer config extra.symfony.require '8.0.*' &&
+        composer update --no-interaction --no-progress &&
+        vendor/bin/phpunit --testsuite=Unit
+      "
 
-  test:watch:
-    desc: 'Watch files and run tests automatically'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} vendor/bin/phpunit-watcher watch'
+  test:matrix:
+    desc: 'Run full test matrix (Symfony 6.4, 7.1, 8.0)'
+    cmds:
+      - task: test:sf64
+      - task: test:sf71
+      - task: test:sf80
+      - cmd: |
+          docker exec {{ .PHP82 }} composer config extra.symfony.require '^6.4|^7.0|^8.0'
+        silent: true
 
   # Code Quality
   stan:
     desc: 'Run PHPStan analysis'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} vendor/bin/phpstan analyse'
+    cmd: 'docker exec {{ .PHP82 }} vendor/bin/phpstan analyse'
 
   cs:
     desc: 'Check code style'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} vendor/bin/php-cs-fixer fix --dry-run --diff'
+    cmd: 'docker exec {{ .PHP82 }} vendor/bin/php-cs-fixer fix --dry-run --diff'
 
   cs:fix:
     desc: 'Fix code style'
-    cmd: 'docker exec {{ .CONTAINER_NAME }} vendor/bin/php-cs-fixer fix'
-    aliases:
-      - fixer
+    cmd: 'docker exec {{ .PHP82 }} vendor/bin/php-cs-fixer fix'
+    aliases: ['fixer']
 
   default:
     desc: 'Show available commands'

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Symfony 8.0 Support**: Full compatibility with Symfony 8.0
+- **PHP 8.4 Support**: Tested and verified with PHP 8.4
+- **Enhanced CI/CD Pipeline**: Matrix testing across all supported PHP and Symfony versions
+
+### Changed
+- **Minimum PHP Version**: Now requires PHP 8.2+ (previously 8.1)
+- **Route Attribute Namespace**: Updated from deprecated `Annotation\Route` to `Attribute\Route`
+- **PHPUnit Configuration**: Updated for PHPUnit 10/11 compatibility
+- **Stricter Deprecation Testing**: Enhanced deprecation detection in tests
+
+### Breaking Changes
+- PHP 8.1 is no longer supported (Symfony 8.0 requires PHP 8.2+)
+
 ## [1.1.0] - 2025-07-14
 
 ### Added
@@ -78,14 +94,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Compatibility
 
 ### Symfony versions
-- ✅ Symfony 6.4.x
+- ✅ Symfony 6.4.x (LTS)
 - ✅ Symfony 7.0.x
-- ✅ Symfony 7.1.x (planned)
+- ✅ Symfony 7.1.x
+- ✅ Symfony 8.0.x
 
 ### PHP versions
 - ✅ PHP 8.2
 - ✅ PHP 8.3
-- 🔄 PHP 8.4 (in testing)
+- ✅ PHP 8.4
 
 ### N8n versions
 - ✅ N8n 1.0+

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,15 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Symfony 8.0 Support**: Full compatibility with Symfony 8.0
 - **PHP 8.4 Support**: Tested and verified with PHP 8.4
 - **Enhanced CI/CD Pipeline**: Matrix testing across all supported PHP and Symfony versions
+- **Full RequestMethod Support**: HTTP client now respects `getN8nRequestMethod()` from payload (GET, POST_JSON, POST_FORM, PUT, PATCH)
 
 ### Changed
 - **Minimum PHP Version**: Now requires PHP 8.2+ (previously 8.1)
 - **Route Attribute Namespace**: Updated from deprecated `Annotation\Route` to `Attribute\Route`
 - **PHPUnit Configuration**: Updated for PHPUnit 10/11 compatibility
 - **Stricter Deprecation Testing**: Enhanced deprecation detection in tests
+- **N8nRequest**: Added `requestMethod` property for proper HTTP method handling
+
+### Fixed
+- **Memory Leak in RequestTracker**: Fixed missing `completeRequest()` call on successful `send()` - requests were never removed from tracker causing memory growth
+- **RequestMethod Ignored**: `N8nPayloadInterface::getN8nRequestMethod()` is now properly used by `N8nHttpClient` to set HTTP method and Content-Type
 
 ### Breaking Changes
-- PHP 8.1 is no longer supported (Symfony 8.0 requires PHP 8.2+)
+- PHP 8.1 is no longer supported
+- Symfony 8.0 requires PHP 8.4+ (Symfony framework requirement)
 
 ## [1.1.0] - 2025-07-14
 
@@ -94,15 +101,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Compatibility
 
 ### Symfony versions
-- ✅ Symfony 6.4.x (LTS)
-- ✅ Symfony 7.0.x
-- ✅ Symfony 7.1.x
-- ✅ Symfony 8.0.x
+- ✅ Symfony 6.4.x (LTS) - PHP 8.2+
+- ✅ Symfony 7.0.x - PHP 8.2+
+- ✅ Symfony 7.1.x - PHP 8.2+
+- ✅ Symfony 8.0.x - PHP 8.4+ (Symfony requirement)
 
 ### PHP versions
-- ✅ PHP 8.2
-- ✅ PHP 8.3
-- ✅ PHP 8.4
+- ✅ PHP 8.2 (Symfony 6.4, 7.x)
+- ✅ PHP 8.3 (Symfony 6.4, 7.x)
+- ✅ PHP 8.4 (all Symfony versions including 8.0)
 
 ### N8n versions
 - ✅ N8n 1.0+

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,15 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": true,
+            "symfony/flex": true
+        },
+        "audit": {
+            "abandoned": "report",
+            "block-insecure": false
+        }
     },
     "scripts": {
         "cs": "php-cs-fixer fix --dry-run --diff",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "friendsofphp/php-cs-fixer": "^3.14",
         "symfony/web-profiler-bundle": "^6.4|^7.0|^8.0",
         "symfony/twig-bundle": "^6.4|^7.0|^8.0",
-        "symfony/monolog-bundle": "^3.10",
         "symfony/dotenv": "^6.4|^7.0|^8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,28 +13,28 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/http-client": "^6.4|^7.0",
-        "symfony/uid": "^6.4|^7.0",
-        "symfony/routing": "^6.4|^7.0",
-        "symfony/event-dispatcher": "^6.4|^7.0",
-        "symfony/console": "^6.4|^7.0",
-        "symfony/config": "^6.4|^7.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/yaml": "^6.4|^7.0",
-        "symfony/property-access": "^6.4|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+        "symfony/http-client": "^6.4|^7.0|^8.0",
+        "symfony/uid": "^6.4|^7.0|^8.0",
+        "symfony/routing": "^6.4|^7.0|^8.0",
+        "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+        "symfony/console": "^6.4|^7.0|^8.0",
+        "symfony/config": "^6.4|^7.0|^8.0",
+        "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+        "symfony/yaml": "^6.4|^7.0|^8.0",
+        "symfony/property-access": "^6.4|^7.0|^8.0",
         "psr/log": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "symfony/phpunit-bridge": "^6.4|^7.0",
-        "symfony/var-dumper": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^6.4|^7.0|^8.0",
+        "symfony/var-dumper": "^6.4|^7.0|^8.0",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.14",
-        "symfony/web-profiler-bundle": "^6.4|^7.0",
-        "symfony/twig-bundle": "^6.4|^7.0",
+        "symfony/web-profiler-bundle": "^6.4|^7.0|^8.0",
+        "symfony/twig-bundle": "^6.4|^7.0|^8.0",
         "symfony/monolog-bundle": "^3.0",
-        "symfony/dotenv": "^6.4|^7.0"
+        "symfony/dotenv": "^6.4|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -58,7 +58,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "^6.4|^7.0"
+            "require": "^6.4|^7.0|^8.0"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "friendsofphp/php-cs-fixer": "^3.14",
         "symfony/web-profiler-bundle": "^6.4|^7.0|^8.0",
         "symfony/twig-bundle": "^6.4|^7.0|^8.0",
-        "symfony/monolog-bundle": "^3.0",
+        "symfony/monolog-bundle": "^3.10",
         "symfony/dotenv": "^6.4|^7.0|^8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,29 +12,29 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/http-client": "^6.4|^7.0",
-        "symfony/uid": "^6.4|^7.0",
-        "symfony/routing": "^6.4|^7.0",
-        "symfony/event-dispatcher": "^6.4|^7.0",
-        "symfony/console": "^6.4|^7.0",
-        "symfony/config": "^6.4|^7.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/yaml": "^6.4|^7.0",
-        "symfony/property-access": "^6.4|^7.0",
+        "php": "^8.2",
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+        "symfony/http-client": "^6.4|^7.0|^8.0",
+        "symfony/uid": "^6.4|^7.0|^8.0",
+        "symfony/routing": "^6.4|^7.0|^8.0",
+        "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+        "symfony/console": "^6.4|^7.0|^8.0",
+        "symfony/config": "^6.4|^7.0|^8.0",
+        "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+        "symfony/yaml": "^6.4|^7.0|^8.0",
+        "symfony/property-access": "^6.4|^7.0|^8.0",
         "psr/log": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
-        "symfony/phpunit-bridge": "^6.4|^7.0",
-        "symfony/var-dumper": "^6.4|^7.0",
+        "phpunit/phpunit": "^10.0|^11.0",
+        "symfony/phpunit-bridge": "^6.4|^7.0|^8.0",
+        "symfony/var-dumper": "^6.4|^7.0|^8.0",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.14",
-        "symfony/web-profiler-bundle": "^6.4|^7.0",
-        "symfony/twig-bundle": "^6.4|^7.0",
+        "symfony/web-profiler-bundle": "^6.4|^7.0|^8.0",
+        "symfony/twig-bundle": "^6.4|^7.0|^8.0",
         "symfony/monolog-bundle": "^3.0",
-        "symfony/dotenv": "^6.4|^7.0"
+        "symfony/dotenv": "^6.4|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -58,7 +58,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "^6.4|^7.0"
+            "require": "^6.4|^7.0|^8.0"
         }
     }
 }

--- a/dev/DevKernel.php
+++ b/dev/DevKernel.php
@@ -7,7 +7,6 @@ namespace Freema\N8nBundle\Dev;
 use Freema\N8nBundle\N8nBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -24,7 +23,6 @@ class DevKernel extends Kernel
         return [
             new FrameworkBundle(),
             new TwigBundle(),
-            new MonologBundle(),
             new WebProfilerBundle(),
             new N8nBundle(),
         ];
@@ -41,20 +39,6 @@ class DevKernel extends Kernel
             ],
             'profiler' => [
                 'only_exceptions' => false,
-            ],
-        ]);
-
-        // Monolog configuration
-        $container->loadFromExtension('monolog', [
-            'handlers' => [
-                'main' => [
-                    'type' => 'stream',
-                    'path' => '%kernel.logs_dir%/%kernel.environment%.log',
-                    'level' => 'debug',
-                ],
-                'console' => [
-                    'type' => 'console',
-                ],
             ],
         ]);
 

--- a/dev/Entity/ModerationResponse.php
+++ b/dev/Entity/ModerationResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Freema\N8nBundle\Dev\Entity;
 
-final readonly class ModerationResponse
+final readonly class ModerationResponse implements \Stringable
 {
     public function __construct(
         public bool $allowed,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,20 @@ services:
     tty: true
     stdin_open: true
     command: >
-      bash -c "apt-get update && apt-get install -y git unzip curl && 
-      curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && 
+      bash -c "apt-get update && apt-get install -y git unzip curl &&
+      curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer &&
+      tail -f /dev/null"
+
+  php84:
+    container_name: n8n-bundle-php84
+    image: php:8.4-cli
+    volumes:
+      - ./:/code:cached
+      - ~/.composer/cache:/root/.composer/cache:cached
+    working_dir: /code
+    tty: true
+    stdin_open: true
+    command: >
+      bash -c "apt-get update && apt-get install -y git unzip curl &&
+      curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer &&
       tail -f /dev/null"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
          cacheDirectory=".phpunit.cache"
@@ -28,6 +28,6 @@
     <php>
         <env name="APP_ENV" value="test"/>
         <env name="APP_DEBUG" value="1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerDeprecations="true">
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
@@ -17,7 +17,7 @@
             <directory>src/Resources</directory>
             <file>src/N8nBundle.php</file>
         </exclude>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="Unit">

--- a/src/Controller/N8nCallbackController.php
+++ b/src/Controller/N8nCallbackController.php
@@ -11,7 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 final class N8nCallbackController extends AbstractController
 {

--- a/src/Domain/N8nRequest.php
+++ b/src/Domain/N8nRequest.php
@@ -7,6 +7,7 @@ namespace Freema\N8nBundle\Domain;
 use Freema\N8nBundle\Contract\N8nPayloadInterface;
 use Freema\N8nBundle\Contract\N8nResponseHandlerInterface;
 use Freema\N8nBundle\Enum\CommunicationMode;
+use Freema\N8nBundle\Enum\RequestMethod;
 
 final readonly class N8nRequest
 {
@@ -17,6 +18,7 @@ final readonly class N8nRequest
         public CommunicationMode $mode,
         public string $clientId,
         public \DateTimeImmutable $createdAt,
+        public RequestMethod $requestMethod = RequestMethod::POST_JSON,
         public ?N8nResponseHandlerInterface $responseHandler = null,
         public ?string $callbackUrl = null,
         public ?int $timeoutSeconds = null,

--- a/src/Service/N8nClient.php
+++ b/src/Service/N8nClient.php
@@ -38,6 +38,7 @@ final class N8nClient implements N8nClientInterface
             mode: $mode,
             clientId: $this->config->clientId,
             createdAt: new \DateTimeImmutable(),
+            requestMethod: $payload->getN8nRequestMethod(),
         );
 
         $this->requestTracker->trackRequest($request);
@@ -93,6 +94,8 @@ final class N8nClient implements N8nClientInterface
                 }
             }
 
+            $this->requestTracker->completeRequest($request->uuid);
+
             return new N8nResponse(
                 uuid: $request->uuid,
                 response: $responseData,
@@ -116,6 +119,7 @@ final class N8nClient implements N8nClientInterface
             mode: CommunicationMode::ASYNC_WITH_CALLBACK,
             clientId: $this->config->clientId,
             createdAt: new \DateTimeImmutable(),
+            requestMethod: $payload->getN8nRequestMethod(),
             responseHandler: $handler,
             callbackUrl: $callbackUrl,
         );
@@ -149,6 +153,7 @@ final class N8nClient implements N8nClientInterface
             mode: CommunicationMode::SYNC,
             clientId: $this->config->clientId,
             createdAt: new \DateTimeImmutable(),
+            requestMethod: $payload->getN8nRequestMethod(),
             timeoutSeconds: $timeoutSeconds,
         );
 

--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -29,6 +29,8 @@ class TestKernel extends Kernel
         $container->loadFromExtension('framework', [
             'secret' => 'test-secret',
             'test' => true,
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
         ]);
 
         $container->loadFromExtension('n8n', [


### PR DESCRIPTION
This pull request introduces full support for Symfony 8.0 and PHP 8.4, updates the minimum PHP requirement to 8.2, and significantly enhances the CI/CD pipeline to test across all supported PHP and Symfony versions. It also improves deprecation detection, updates PHPUnit and related configuration for better compatibility, and makes several dependency and codebase adjustments to ensure compatibility with the latest ecosystem.

**Compatibility and Requirements Updates**
- Dropped support for PHP 8.1; minimum required PHP version is now 8.2, and all relevant Symfony and dev dependencies now allow ^8.0. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L15-R37) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L61-R61)
- Added Symfony 8.0 and PHP 8.4 as officially supported versions in documentation and version tracking. [[1]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeR8-R23) [[2]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL81-R105) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R21)

**CI/CD Pipeline Improvements**
- CI workflow now tests all combinations of PHP 8.2/8.3/8.4 and Symfony 6.4/7.x/8.0, with improved caching and matrix strategies; added deprecation checks and coverage jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR5-R7) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R38) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL45-R50) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL59-R108) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL85-R228)
- Updated PHP-CS-Fixer and PHPStan jobs to use latest tool versions and run against all supported PHP versions.

**Code and Dependency Adjustments**
- Updated `composer.json` to support Symfony 8.0 and PHPUnit 11, and to reflect new PHP requirements. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L15-R37) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L61-R61)
- Updated route attributes in controllers from the deprecated `Annotation\Route` to the new `Attribute\Route` namespace for Symfony 8 compatibility.
- Made `ModerationResponse` implement `\Stringable` for improved type safety.

**Testing and Quality Enhancements**
- Updated PHPUnit configuration for compatibility with PHPUnit 10/11 and stricter deprecation detection. [[1]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L3-R3) [[2]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L31-R31)
- Added stricter Symfony test kernel configuration for error handling.

**Tooling**
- Allowed unsupported PHP versions in PHP-CS-Fixer config to prevent tool failures during matrix testing.