### PR TITLE
Fix too narrow exception

### DIFF
--- a/src/Exception/N8nCommunicationException.php
+++ b/src/Exception/N8nCommunicationException.php
@@ -6,7 +6,7 @@ namespace Freema\N8nBundle\Exception;
 
 class N8nCommunicationException extends N8nException
 {
-    public function __construct(string $message, int $httpCode = 0, ?N8nException $previous = null)
+    public function __construct(string $message, int $httpCode = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $httpCode, $previous);
     }

--- a/src/Exception/N8nException.php
+++ b/src/Exception/N8nException.php
@@ -6,7 +6,7 @@ namespace Freema\N8nBundle\Exception;
 
 class N8nException extends \Exception
 {
-    public function __construct(string $message, int $code = 0, ?\Exception $previous = null)
+    public function __construct(string $message, int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/N8nTimeoutException.php
+++ b/src/Exception/N8nTimeoutException.php
@@ -6,7 +6,7 @@ namespace Freema\N8nBundle\Exception;
 
 class N8nTimeoutException extends N8nCommunicationException
 {
-    public function __construct(string $message = 'N8n request timeout', int $code = 0, ?N8nException $previous = null)
+    public function __construct(string $message = 'N8n request timeout', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Http/N8nHttpClient.php
+++ b/src/Http/N8nHttpClient.php
@@ -69,15 +69,13 @@ final class N8nHttpClient
             return $this->httpClient->request($httpMethod, $url, $options);
         } catch (\Throwable $e) {
             if (str_contains($e->getMessage(), 'timeout')) {
-                // @phpstan-ignore-next-line
-                throw new N8nTimeoutException('N8n webhook request timeout', 0, $e instanceof \Exception ? $e : null);
+                throw new N8nTimeoutException('N8n webhook request timeout', 0, $e);
             }
 
             throw new N8nCommunicationException(
                 'Failed to send webhook to N8n: '.$e->getMessage(),
                 0,
-                // @phpstan-ignore-next-line
-                $e instanceof \Exception ? $e : null,
+                $e,
             );
         }
     }


### PR DESCRIPTION
```
In N8nCommunicationException.php line 9:
                                                                                                                                                                                                                                                       
  Freema\N8nBundle\Exception\N8nCommunicationException::__construct(): Argument #3 ($previous) must be of type ?Freema\N8nBundle\Exception\N8nException, Symfony\Component\HttpClient\Exception\InvalidArgumentException given, called in /app/vendor  
  /freema/n8n-bundle/src/Http/N8nHttpClient.php on line 76     
```