### PR TITLE
docs: clarify requirements table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ Elegant integration between Symfony applications and n8n workflow automation pla
 
 ## Requirements
 
-| Version  | PHP  | Symfony  |
-|----------|------|----------|
-| 2.x      | ^8.2 | 6.4, 7.x |
-| 2.x      | ^8.4 | 8.0      |
-| 1.3      | ^8.2 | 6.4, 7.x |
-| 1.0-1.2  | ^8.1 | 6.4, 7.0 |
+| Bundle  | PHP    | Symfony       |
+|---------|--------|---------------|
+| 2.x     | 8.2+ * | 6.4, 7.x, 8.0 |
+| 1.3     | 8.2+   | 6.4, 7.x      |
+| 1.0–1.2 | 8.1+   | 6.4, 7.0      |
 
-> **Note:** Symfony 8.0 requires PHP 8.4+
+> \* Symfony 8.0 itself requires PHP 8.4+. On PHP 8.2/8.3 the bundle runs with Symfony 6.4 or 7.x; use PHP 8.4+ if you want Symfony 8.0.
 
 ## Quick Start
 


### PR DESCRIPTION
The requirements table had two `2.x` rows, which read like a duplicate/typo. Rewrote it to one row per bundle major and clarified the PHP/Symfony relationship.

- One row per bundle major (`2.x`, `1.3`, `1.0–1.2`).
- Symfony 8 support is a 2.x feature, so 1.x rows no longer list `8.0`.
- Footnote: Symfony 8.0 needs PHP 8.4+, while PHP 8.2/8.3 works with Symfony 6.4/7.x.